### PR TITLE
prune: merge modularity.adoc into modular-design.adoc

### DIFF
--- a/src/modules/ROOT/nav.adoc
+++ b/src/modules/ROOT/nav.adoc
@@ -344,7 +344,6 @@
 ** xref:modeling.adoc[Modeling]
 ** xref:modular-design.adoc[Modular design]
 ** xref:modular-monolith.adoc[Modular monolith]
-** xref:modularity.adoc[Modularity]
 ** xref:monitoring.adoc[Monitoring]
 ** xref:monolith.adoc[Monolith]
 ** xref:multi-tenant.adoc[Multi-tenant]

--- a/src/modules/ROOT/pages/index.adoc
+++ b/src/modules/ROOT/pages/index.adoc
@@ -427,7 +427,6 @@ I'm actively researching these topics at this time:
 * *xref:modeling.adoc[Modeling]* 🌱
 * *xref:modular-design.adoc[Modular design]* 🌱
 * *xref:modular-monolith.adoc[Modular monolith]* 🌱
-* *xref:modularity.adoc[Modularity]* 🌱
 * *xref:monitoring.adoc[Monitoring]* 🌱
 * *xref:monolith.adoc[Monolith]* 🌱
 * *xref:multi-tenant.adoc[Multi-tenant]* 🌱

--- a/src/modules/ROOT/pages/microservices.adoc
+++ b/src/modules/ROOT/pages/microservices.adoc
@@ -7,7 +7,7 @@
 // TODO: https://medium.com/hashmapinc/the-what-why-and-how-of-a-microservices-architecture-4179579423a9
 // TODO: https://newsletter.systemdesign.one/p/netflix-microservices
 
-The microservice pattern is a subset of *xref:service-oriented-architecture.adoc[service-oriented architecture (SOA)]*. The microservice architecture can be thought of as an extreme form of service-oriented design, in which principles like *xref:separation-of-concerns.adoc[separation of concerns]*, *xref:modularity.adoc[modularity]*, and *xref:decoupling.adoc[decoupling]* are applied to their fullest extent.
+The microservice pattern is a subset of *xref:service-oriented-architecture.adoc[service-oriented architecture (SOA)]*. The microservice architecture can be thought of as an extreme form of service-oriented design, in which principles like *xref:separation-of-concerns.adoc[separation of concerns]*, *xref:modular-design.adoc[modularity]*, and *xref:decoupling.adoc[decoupling]* are applied to their fullest extent.
 
 There is no definitive list of features that distinguish microservices from more general service-oriented designs, but it is widely accepted that the difference is one of granularity. Individual microservices are typically very small, scoped to a single business function, and independently deployable thanks to maximized *xref:decoupling.adoc[decoupling]* between services. There also tends to be a bias toward *xref:asynchronous-communication.adoc[asynchronous communication]* between services, particularly indirect *xref:message-driven-architecture.adoc[message-driven]* communication using lightweight messaging protocols, rather than direct service-to-service calls. These constraints do not necessarily apply to service-oriented architecture.
 

--- a/src/modules/ROOT/pages/modular-design.adoc
+++ b/src/modules/ROOT/pages/modular-design.adoc
@@ -4,4 +4,4 @@ Modular design is a software design approach that emphasizes the separation of c
 
 A key focus of modular design is to hide *xref:complexity.adoc[complexity]* through *xref:abstraction.adoc[abstraction]*, and to support the *[reusability]* of units of code.
 
-See also *xref:modularity.adoc[modularity]*.
+// TODO: Modularity is a static *[quality]* of a software system. Modularity is related to *[abstraction]*, which is a general concept in software design. Modularity is a specific application of abstraction in software design, where the system is divided into smaller, self-contained modules that can be developed and maintained independently, and which hide their *[complexity]* from other parts of the system - so that users of the module have minimal *cognitive overhead* to understand how to use the module.

--- a/src/modules/ROOT/pages/modularity.adoc
+++ b/src/modules/ROOT/pages/modularity.adoc
@@ -1,7 +1,0 @@
-= Modularity
-
-// TODO: A static *[quality]* of a software system.
-
-// Modularity is related to *[abstraction]*, which is a general concept in software design. Modularity is a specific application of abstraction in software design, where the system is divided into smaller, self-contained modules that can be developed and maintained independently, and which hide their *[complexity]* from other parts of the system - so that users of the module have minimal *cognitive overhead* to understand how to use the module.
-
-See also *xref:modular-design.adoc[modular design]*.

--- a/src/modules/ROOT/pages/test-driven-development.adoc
+++ b/src/modules/ROOT/pages/test-driven-development.adoc
@@ -50,7 +50,7 @@ Writing tests first requires programmers to think about how to implement changes
 
 Advocates of TDD argue that it leads to:
 
-* Better design and higher code quality, due to enforcement of *xref:modularity.adoc[modularity]* and well-defined *xref:interfaces.adoc[interfaces]*.
+* Better design and higher code quality, due to enforcement of *xref:modular-design.adoc[modularity]* and well-defined *xref:interfaces.adoc[interfaces]*.
 * Fewer defects, because testing is shifted left, meaning errors are caught early in the development lifecycle.
 * Confident refactoring, as you end up with comprehensive test coverage that makes it much easier to make changes with minimized risk of breaking existing functionality.
 


### PR DESCRIPTION
## Summary

Merged the empty stub `modularity.adoc` into `modular-design.adoc` (the survivor with real content).

### Changes
- **Survivor:** `modular-design.adoc` — preserved the TODO content from modularity.adoc as comments
- **Deleted:** `modularity.adoc` (was an empty TODO stub)
- **Repointed xrefs:** `microservices.adoc`, `test-driven-development.adoc` → `modular-design.adoc`
- **Removed from index.adoc and nav.adoc:** `modularity.adoc` entry

### Rationale
Both pages covered the same concept (modular design / modularity). `modularity.adoc` had no actual content — just commented-out TODOs and a "See also" link to `modular-design.adoc`.