### PR TITLE
prune: merge consensus.adoc into consensus-algorithms.adoc

### DIFF
--- a/src/modules/ROOT/nav.adoc
+++ b/src/modules/ROOT/nav.adoc
@@ -108,7 +108,6 @@
 ** xref:compliance.adoc[Compliance]
 ** xref:compliance-testing.adoc[Compliance testing]
 ** xref:composition.adoc[Composition]
-** xref:consensus.adoc[Consensus]
 ** xref:case.adoc[Computer-Aided Software Engineering (CASE)]
 ** xref:computer-science.adoc[Computer science]
 ** xref:concatenative-language.adoc[Concatenative language]

--- a/src/modules/ROOT/pages/consensus-algorithms.adoc
+++ b/src/modules/ROOT/pages/consensus-algorithms.adoc
@@ -1,6 +1,8 @@
 = Consensus algorithms
 
-In *xref:distributed-system.adoc[distributed software]*, *[nodes]* need to work together to maintain a *xref:consistency.adoc[consistent]* state. However, due to the inherent challenges of distributed software systems – such as network *xref:latency.adoc[latency]*, node *[failures]*, and *[asynchrony]* – it is difficult to achieve *xref:consensus.adoc[consensus]* on the state of the system.
+// TODO: https://medium.com/@sourabhatta1819/consensus-in-distributed-system-ac79f8ba2b8c
+
+In *xref:distributed-system.adoc[distributed software]*, *[nodes]* need to work together to maintain a *xref:consistency.adoc[consistent]* state. However, due to the inherent challenges of distributed software systems – such as network *xref:latency.adoc[latency]*, node *[failures]*, and *[asynchrony]* – it is difficult to achieve *[consensus]* on the state of the system.
 
 Consensus algorithms address these challenges by ensuring that all participating nodes agree on some state or sequence of events, even when some nodes might fail or act maliciously.
 

--- a/src/modules/ROOT/pages/consensus.adoc
+++ b/src/modules/ROOT/pages/consensus.adoc
@@ -1,3 +1,0 @@
-= Consensus
-
-// TODO: https://medium.com/@sourabhatta1819/consensus-in-distributed-system-ac79f8ba2b8c

--- a/src/modules/ROOT/pages/index.adoc
+++ b/src/modules/ROOT/pages/index.adoc
@@ -159,7 +159,6 @@ I'm actively researching these topics at this time:
 * *xref:compliance.adoc[Compliance]* 🌱
 * *xref:compliance-testing.adoc[Compliance testing]* 🌿
 * *xref:composition.adoc[Composition]* 🌱
-* *xref:consensus.adoc[Consensus]* 🌱
 * *xref:case.adoc[Computer-Aided Software Engineering (CASE)]* 🌱
 * *xref:change-data-capture.adoc[Change data capture (CDC)]* 🌱
 * *xref:computer-science.adoc[Computer science]* 🌱


### PR DESCRIPTION
## Summary

Merged the empty stub `consensus.adoc` into `consensus-algorithms.adoc` (the survivor with full content).

### Changes
- **Survivor:** `consensus-algorithms.adoc` — preserved the TODO resource link from the stub
- **Deleted:** `consensus.adoc` (was an empty TODO stub)
- **Fixed self-reference:** The `xref:consensus.adoc[consensus]` link inside `consensus-algorithms.adoc` was converted to a plain `*[consensus]*` emphasis (no longer a cross-reference now that the separate page is gone)
- **Removed from index.adoc and nav.adoc:** `consensus.adoc` entry

### Rationale
`consensus.adoc` had no content — just a title and one TODO comment. `consensus-algorithms.adoc` covers the same concept with full content (Paxos, Raft, etc.).